### PR TITLE
Fix: use offline entity resolver for the MyBatis DTDs

### DIFF
--- a/src/main/java/com/example/nativedemo/MyBatisNativeConfiguration.java
+++ b/src/main/java/com/example/nativedemo/MyBatisNativeConfiguration.java
@@ -132,8 +132,8 @@ public class MyBatisNativeConfiguration {
           HashSet.class
       ).forEach(x -> hints.reflection().registerType(x, MemberCategory.values()));
       Stream.of(
-          "org/apache/ibatis/builder/xml/.*.dtd",
-          "org/apache/ibatis/builder/xml/.*.xsd"
+          "org/apache/ibatis/builder/xml/*.dtd",
+          "org/apache/ibatis/builder/xml/*.xsd"
       ).forEach(hints.resources()::registerPattern);
 
       hints.serialization().registerType(SerializedLambda.class);


### PR DESCRIPTION
故障描述：在使用`mapper.xml`配置的时候，以`AOT`模式启动应用，会始终从互联网`https://mybatis.org`校验`mybatis-3-mapper.dtd`文件，无法以离线的方式处理，导致应用启动时加载`Mapper.xml`文件速度非常慢，100个`maper`文件的应用，启动时间在70秒左右。

参考：https://github.com/mybatis/spring-boot-starter/issues/852

日志信息：

```java
 _   |_  _ _|_. ___ _ |    _ ,
| | |\/|_)(_| | |_\  |_)||_|_\ ,
     /               |         ,
                        3.5.3.2 ,
2023-08-28 16:17:40.924 | DEBUG [] main | com.baomidou.mybatisplus.core.toolkit.Sequence | Initialization Sequence datacenterId:16 workerId:12,
2023-08-28 16:17:42.300 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@7403bfd05 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:42.424 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@2fb9097422 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:42 GMT}{Via: 1.1 varnish}{Age: 592}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1188}{X-Timer: S1693210662.420849,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: c944a5ea29282ba39f8491e0d56767e37ab0aac2},
2023-08-28 16:17:42.699 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@37d9bf5b5 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:42.825 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@18627da822 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:42 GMT}{Via: 1.1 varnish}{Age: 593}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1189}{X-Timer: S1693210663.820951,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: c386d437e3a6eb9ea29540342d835b721690ff3c},
2023-08-28 16:17:43.401 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@7b5316fb5 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:43.506 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@8c4a1de22 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:43 GMT}{Via: 1.1 varnish}{Age: 593}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1190}{X-Timer: S1693210664.501820,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 9ec29027c505eb3fab58abcd6d694980719a92fb},
2023-08-28 16:17:43.545 | DEBUG [] main | org.springframework.core.env.StandardEnvironment | Activating profile 'dev',
2023-08-28 16:17:43.545 | DEBUG [] main | org.springframework.context.support.GenericApplicationContext | Refreshing FeignClientFactory-leafFeignService,
2023-08-28 16:17:43.601 | INFO  [] main | org.springframework.cloud.openfeign.FeignClientFactoryBean | For 'hongyan-boot-leaf-service' URL not provided. Will try picking an instance via load-balancing.,
2023-08-28 16:17:43.631 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@3dc707085 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:43.859 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@6d4d929722 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:43 GMT}{Via: 1.1 varnish}{Age: 594}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1191}{X-Timer: S1693210664.744415,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 68390c9b8b8ce90245883c49d15f58d330e64d85},
2023-08-28 16:17:43.969 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@6efc7c205 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:44.738 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@292c86a822 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:44 GMT}{Via: 1.1 varnish}{Age: 594}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1192}{X-Timer: S1693210664.062968,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: c9ffead182d8110b111c3435eff83df35b04bece},
2023-08-28 16:17:44.748 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@4e3f30595 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:44.844 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@4016f6c622 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:44 GMT}{Via: 1.1 varnish}{Age: 595}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1194}{X-Timer: S1693210665.842308,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 3baa4bbd66d1f36c96031d46f8a5fcde9fc6e1f3},
2023-08-28 16:17:45.066 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@28b2164c5 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:45.295 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@1223f1f722 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:45 GMT}{Via: 1.1 varnish}{Age: 595}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1195}{X-Timer: S1693210665.160344,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 3950cbc52af57c542b94f10e76816ec6d8c1e60c},
2023-08-28 16:17:45.663 | WARN  [] main | com.baomidou.mybatisplus.core.metadata.TableInfoHelper | Can not find table primary key in Class: "com.demo.boot.admin.entity.conversation.UserConversationMessage".,
2023-08-28 16:17:45.663 | WARN  [] main | com.baomidou.mybatisplus.core.injector.DefaultSqlInjector | class com.demo.boot.admin.entity.conversation.UserConversationMessage ,Not found @TableId annotation, Cannot use Mybatis-Plus 'xxById' Method.,
2023-08-28 16:17:45.673 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@22f1b7995 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:45.864 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@6b6bea3b22 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:45 GMT}{Via: 1.1 varnish}{Age: 596}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1198}{X-Timer: S1693210666.772562,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 5443a58a8e2d6f3e2840c50d167a318be85c525a},
2023-08-28 16:17:45.961 | WARN  [] main | com.baomidou.mybatisplus.core.metadata.TableInfoHelper | Can not find table primary key in Class: "com.demo.boot.admin.entity.conversation.UserConversationMessageStatus".,
2023-08-28 16:17:45.962 | WARN  [] main | com.baomidou.mybatisplus.core.injector.DefaultSqlInjector | class com.demo.boot.admin.entity.conversation.UserConversationMessageStatus ,Not found @TableId annotation, Cannot use Mybatis-Plus 'xxById' Method.,
2023-08-28 16:17:45.968 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@56eb83cb5 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:46.068 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@344a41b022 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:46 GMT}{Via: 1.1 varnish}{Age: 596}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1199}{X-Timer: S1693210666.063406,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 8052b4b22cd5e583727a7d7e756f1c0d70edfe7b},
2023-08-28 16:17:46.305 | WARN  [] main | com.baomidou.mybatisplus.core.metadata.TableInfoHelper | Can not find table primary key in Class: "com.demo.boot.admin.entity.conversation.UserConversationMessageLog".,
2023-08-28 16:17:46.306 | WARN  [] main | com.baomidou.mybatisplus.core.injector.DefaultSqlInjector | class com.demo.boot.admin.entity.conversation.UserConversationMessageLog ,Not found @TableId annotation, Cannot use Mybatis-Plus 'xxById' Method.,
2023-08-28 16:17:46.334 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@566c8aec5 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:46.591 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@1de4916422 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:46 GMT}{Via: 1.1 varnish}{Age: 596}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1200}{X-Timer: S1693210666.428855,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: bdb9035cafc7bbfd16449a4c210cb840ba50a69d},
2023-08-28 16:17:46.918 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@caa23475 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:47.501 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@1f984daf22 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:47 GMT}{Via: 1.1 varnish}{Age: 597}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1201}{X-Timer: S1693210667.013987,VS0,VE1}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 28bb7cda71dff8fc0b7c097f86b7618ba4f61519},
2023-08-28 16:17:48.145 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@6b3fcfe35 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:48.374 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@df04d8a22 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:48 GMT}{Via: 1.1 varnish}{Age: 598}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1205}{X-Timer: S1693210668.238779,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: d5f880e72c69c0ef24305a8f8bee90fd0ceca269},
2023-08-28 16:17:49.336 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@68ec48cf5 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:49.435 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@9bb07e822 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:49 GMT}{Via: 1.1 varnish}{Age: 599}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1209}{X-Timer: S1693210669.431435,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 282383673b1ad9d1fa69d97b631739dd6ef54a24},
2023-08-28 16:17:50.598 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@3df8e4af5 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:50.780 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@1b7317cd22 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:50 GMT}{Via: 1.1 varnish}{Age: 1}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 1}{X-Timer: S1693210671.694274,VS0,VE1}{Vary: Accept-Encoding}{X-Fastly-Request-ID: d5b871e1992171304d33f1e503d673648cdd4809},
2023-08-28 16:17:51.225 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@5355d0345 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:51.319 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@984b75022 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:51 GMT}{Via: 1.1 varnish}{Age: 2}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 4}{X-Timer: S1693210671.319605,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 32a6bb5558f9be521b9ba67814d7704f86bcc1a0},
2023-08-28 16:17:52.116 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@1be77b485 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:52.214 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@3792bc9822 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:52 GMT}{Via: 1.1 varnish}{Age: 3}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 6}{X-Timer: S1693210672.210742,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 4dae3ae924fb53690355a0d3879fd2639ff88456},
2023-08-28 16:17:53.765 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@e946cb25 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
2023-08-28 16:17:53.862 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@733e091522 pairs: {null: HTTP/1.1 200 OK}{Connection: keep-alive}{Content-Length: 7458}{Server: GitHub.com}{Content-Type: application/xml-dtd}{Last-Modified: Wed, 07 Sep 2022 23:28:43 GMT}{Access-Control-Allow-Origin: *}{ETag: "6319292b-1d22"}{expires: Tue, 22 Aug 2023 22:28:33 GMT}{Cache-Control: max-age=600}{x-proxy-cache: MISS}{X-GitHub-Request-Id: AA4C:0397:901881:97E565:64E53439}{Accept-Ranges: bytes}{Date: Mon, 28 Aug 2023 08:17:53 GMT}{Via: 1.1 varnish}{Age: 4}{X-Served-By: cache-nrt-rjtf7700041-NRT}{X-Cache: HIT}{X-Cache-Hits: 8}{X-Timer: S1693210674.860978,VS0,VE0}{Vary: Accept-Encoding}{X-Fastly-Request-ID: 9e348a1a8f8c5089e0b6726ecaafc5e913acadee},
2023-08-28 16:17:54.355 | DEBUG [] main | sun.net.www.protocol.http.HttpURLConnection | sun.net.www.MessageHeader@c3285915 pairs: {GET /dtd/mybatis-3-mapper.dtd HTTP/1.1: null}{User-Agent: Java/17.0.7}{Host: mybatis.org}{Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2}{Connection: keep-alive},
```